### PR TITLE
fix: correct port in demo-http-route.yaml to match demo service port

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,5 +15,5 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8000
+      port: 80
 ---


### PR DESCRIPTION
This PR fixes the port mismatch in the demo HTTPRoute manifest by changing the backendRef port from 8000 to 80, matching the demo service port. This resolves the issue where the demo app was inaccessible via the Istio ingress gateway.