### PR TITLE
Recreate fix for demo-http-route backend port

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,5 +15,5 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8000
+      port: 80
 ---


### PR DESCRIPTION
This PR recreates the fix to update the backend port to 80 for `demo-http-route`. This corrects routing to the demo service through the ingress gateway.

- Updated backendRefs.port from 8000 to 80 in `demo/demo-http-route.yaml`

Please review and merge the changes.