### PR TITLE
fix: correct HTTPRoute backend port for demo service

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,5 +15,5 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80
 ---


### PR DESCRIPTION
This PR fixes the backend port in the HTTPRoute resource `demo-http-route.yaml` to match the demo service exposing port 80 instead of 8080. This resolves the ingress gateway routing issue for the demo service.