### PR TITLE
Fix backendRef port in demo-http-route from 8080 to 80 to match demo service port

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,5 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
----
+      port: 80


### PR DESCRIPTION
This PR fixes the port mismatch in the HTTPRoute `demo-http-route` backendRef where port was incorrectly set to 8080 instead of 80, which matches the demo service port. This should resolve the issue where the demo service was unreachable via the Istio ingress gateway.