### PR TITLE
fix: update HTTPRoute backend port from 8080 to 80 to match demo service

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
The backend port in demo-http-route.yaml was incorrectly set to 8080 while the demo service is exposed on port 80. This PR fixes the port to 80 to restore connectivity through the Istio ingress gateway.