### PR TITLE
fix: Update demo-http-route backend port to 80 to match demo service

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the port mismatch issue in the demo-http-route manifest. Previously, the backend port was set to 8080, but the demo service exposes port 80. This caused ingress gateway routing failure. The port is now updated to 80 to match the demo service, enabling proper routing and access via the Istio ingress gateway.