### PR TITLE
Fix backend service port in demo-http-route

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
Fix the backend reference port in demo-http-route from 8080 to 80 to match the demo service port.

This fixes the issue where the demo service was not reachable from the Istio ingress gateway due to port mismatch.