### PR TITLE
Fix demo-http-route backend port to 80

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the demo-http-route backend service port from 8080 to 80 to match the actual demo service port, resolving the service reachability issue from Istio ingress gateway.