### PR TITLE
fix: update demo-http-route backendRefs port to 80 to match demo service port

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the port mismatch issue in the demo-http-route HTTPRoute resource. The backendRefs port is updated from 8080 to 80 to match the demo service port, resolving routing issues from Istio ingress gateway to demo service.