### PR TITLE
fix: align HTTPRoute backend port to demo service port 80

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR updates the HTTPRoute backend port to 80 to match the demo service port and fix ingress routing issue.