### PR TITLE
fix: correct HTTPRoute backendRef port for demo service to 80

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the backendRef port in the demo-http-route HTTPRoute resource to match the demo service port 80. This corrects the routing so that the demo service is reachable via the Istio ingress gateway.